### PR TITLE
Set output buffer explicitly

### DIFF
--- a/vision-apps/Classification-DeepOceanCore/README.md
+++ b/vision-apps/Classification-DeepOceanCore/README.md
@@ -4,7 +4,7 @@ This vision app demonstrates how to accelerate a neural network using the Deep O
 
 ## Getting Started
 ### Prerequisites
-![IDS NXT SDK Version](https://img.shields.io/badge/NXT_API-v2.1.0-008A96.svg)  ![IDS NXT OS Version](https://img.shields.io/badge/NXT_OS-v1.1.x-008A96.svg)  
+![IDS NXT SDK Version](https://img.shields.io/badge/NXT_API-v2.3.0-008A96.svg)  ![IDS NXT OS Version](https://img.shields.io/badge/NXT_OS-v1.1.x-008A96.svg)  
 
 ## Hint
 To use your own CNN, copy the .cnn file into ./cnn directory.

--- a/vision-apps/Classification-DeepOceanCore/README.md
+++ b/vision-apps/Classification-DeepOceanCore/README.md
@@ -4,7 +4,7 @@ This vision app demonstrates how to accelerate a neural network using the Deep O
 
 ## Getting Started
 ### Prerequisites
-![IDS NXT SDK Version](https://img.shields.io/badge/NXT_API-v2.3.0-008A96.svg)  ![IDS NXT OS Version](https://img.shields.io/badge/NXT_OS-v1.1.x-008A96.svg)  
+![IDS NXT SDK Version](https://img.shields.io/badge/NXT_API-v2.3.0-008A96.svg)  ![IDS NXT OS Version](https://img.shields.io/badge/NXT_OS-v1.3.x-008A96.svg)  
 
 ## Hint
 To use your own CNN, copy the .cnn file into ./cnn directory.

--- a/vision-apps/Classification-DeepOceanCore/classification.pro
+++ b/vision-apps/Classification-DeepOceanCore/classification.pro
@@ -9,7 +9,7 @@ HEADERS += myapp.h myvision.h myengine.h
 DEFINES +=
 DISTFILES +=
 #Mandatory params
-NXT_SDK = 2.1.0
+NXT_SDK = 2.3.0
 AVATAR = avatar.png
 MANIFEST = manifest.json
 TRANSLATION = translation.json

--- a/vision-apps/Classification-DeepOceanCore/manifest.json
+++ b/vision-apps/Classification-DeepOceanCore/manifest.json
@@ -1,7 +1,7 @@
 {
     "Name": "classification",
     "Manufacturer": "IDS Imaging Development Systems GmbH",
-    "Version": "1.0.0",
+    "Version": "1.0.1",
     "Type": "VApp",
     "Language":
     {

--- a/vision-apps/Classification-DeepOceanCore/myvision.cpp
+++ b/vision-apps/Classification-DeepOceanCore/myvision.cpp
@@ -21,7 +21,8 @@ void MyVision::process()
             // #CLASSIFICATION
             // process image with deep ocean core.
             // Scale the image to the input size of the cnn. If you don't scale it the NXT Framework will scale it which  can lower performance
-            _result = _cnnData.processImage(img->getQImage().scaled(_cnnData.inputSize(), Qt::IgnoreAspectRatio, Qt::FastTransformation));
+            _result = _cnnData.processImage(img->getQImage().scaled(_cnnData.inputSize(), Qt::IgnoreAspectRatio, Qt::FastTransformation),
+                                            QStringLiteral("Classification"));
 
             img->visionOK("", "");
         } else { // Deep ocean core is not initialized. This can happen if no cnn is ativated.

--- a/vision-apps/MultiCNN/manifest.json
+++ b/vision-apps/MultiCNN/manifest.json
@@ -1,7 +1,7 @@
 {
     "Name": "multicnn",
     "Manufacturer": "IDS Imaging Development Systems GmbH",
-    "Version": "1.0.0",
+    "Version": "1.0.1",
     "Type": "VApp",
     "Language":
     {

--- a/vision-apps/MultiCNN/myvision.cpp
+++ b/vision-apps/MultiCNN/myvision.cpp
@@ -22,8 +22,12 @@ void MyVision::process()
             for (auto &cnn : _cnnData) {
                 if (cnn) {
                     // process image with deep ocean core.
-                    // Scale the image to the input size of the cnn. If you don't scale it the NXT Framework will scale it which  can lower performance
-                    _result.push_back(cnn.processImage(img->getQImage().scaled(cnn.inputSize(), Qt::IgnoreAspectRatio, Qt::FastTransformation)));
+                    // Scale the image to the input size of the cnn. If you don't scale it the NXT Framework will scale
+                    // it which  can lower performance
+                    _result.push_back(cnn.processImage(img->getQImage().scaled(cnn.inputSize(),
+                                                                               Qt::IgnoreAspectRatio,
+                                                                               Qt::FastTransformation),
+                                                       QStringLiteral("Classification")));
                 }
             }
 


### PR DESCRIPTION
If the output buffer is not explicitly specified, the result of a classification may be incorrect if a classification CNN that supports heatmaps is used.