### PR TITLE
Support new CNN file extensions

### DIFF
--- a/vision-apps/MultiCNN/MultiCNN.pro
+++ b/vision-apps/MultiCNN/MultiCNN.pro
@@ -5,7 +5,7 @@ QT += core widgets gui dbus
 SOURCES += myapp.cpp myvision.cpp myengine.cpp main.cpp
 HEADERS += myapp.h myvision.h myengine.h
 
-NXT_SDK = 2.6.0
+NXT_SDK = 3.1.0
 AVATAR = avatar.png
 MANIFEST = manifest.json
 TRANSLATION = translation.json

--- a/vision-apps/MultiCNN/manifest.json
+++ b/vision-apps/MultiCNN/manifest.json
@@ -1,7 +1,7 @@
 {
     "Name": "multicnn",
     "Manufacturer": "IDS Imaging Development Systems GmbH",
-    "Version": "1.1.2",
+    "Version": "3.1.0",
     "Type": "VApp",
     "Language":
     {

--- a/vision-apps/MultiCNN/myapp.cpp
+++ b/vision-apps/MultiCNN/myapp.cpp
@@ -15,9 +15,9 @@ MyApp::MyApp(int& argc, char** argv)
   , _disableCnnAction{"disable"}
   , _vappInfo{"cnninfo"} {
     // initialization
-    auto filtertext = TranslatedText{
-        QMap<QString, QString>{{"en", "IDS CNN File |*.cnn"}, {"de", "IDS CNN Datei |*.cnn"}}};
-    _cnnPackage->setFilter({filtertext});
+    QList<TranslatedText> filtercnn;
+    filtercnn.append("IDS NXT rio/rome classification model |*.rcla; *.cnn");
+    _cnnPackage->setFilter(filtercnn);
     _cnnPackage->setWritable(true);
 
     updateCnnFileDeletableProperty();


### PR DESCRIPTION
Added the new file extension ".rcla" to the configurable file filter for the CNN upload in the classification vision app.
With NXT 3.1.0 the file extensions were adjusted. The new file extensions for CNNs trained for IDS NXT OS Version 3.1.0 for IDS NXT rio and IDS NXT rome are *.rcla, *.rdet and *.rano.